### PR TITLE
test: fix(main,x11): fix build ncspot and ncspot-mpris

### DIFF
--- a/packages/ncspot/build.sh
+++ b/packages/ncspot/build.sh
@@ -3,15 +3,13 @@ TERMUX_PKG_DESCRIPTION="An ncurses Spotify client written in Rust"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.2.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/hrkfdn/ncspot/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=6bd08609a56aa5854a1964c9a872fe58b69a768d7d94c874d40d7a8848241213
 TERMUX_PKG_DEPENDS="dbus, pulseaudio"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
-
 TERMUX_PKG_CONFLICTS="ncspot-mpris"
-
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --no-default-features
 --features termion_backend,pulseaudio_backend
@@ -29,4 +27,25 @@ termux_step_pre_configure() {
 	cargo install --force --locked bindgen-cli@0.69.5
 
 	export TARGET_CMAKE_GENERATOR="Ninja"
+
+	# Setup subsequent cmake running inside cargo
+	# Crate used to invoke cmake does not work fine with cross-compilation so we wrap cmake
+	_CMAKE="$TERMUX_PKG_TMPDIR/bin/cmake"
+	mkdir -p "$(dirname "$_CMAKE")"
+
+	echo "#!$(readlink /proc/$$/exe)" > "$_CMAKE"
+	echo "echo CMAKE \"\$@\"" >> "$_CMAKE"
+	echo "[[ \"\$@\" =~ \"--build\" ]] && exec $(command -v cmake) \"\$@\" || \
+	exec $(command -v cmake) \
+	-DCMAKE_ANDROID_STANDALONE_TOOLCHAIN=\"$TERMUX_STANDALONE_TOOLCHAIN\" \
+	-DCMAKE_SYSTEM_NAME=Android \
+	-DCMAKE_SYSTEM_VERSION=$TERMUX_PKG_API_LEVEL \
+	-DCMAKE_LINKER=\"$TERMUX_STANDALONE_TOOLCHAIN/bin/$LD\" \
+	-DCMAKE_MAKE_PROGRAM=\"$(command -v ninja)\" \"\$@\"" >> "$_CMAKE"
+	chmod +x "$_CMAKE"
+
+	export PATH="$(dirname "$_CMAKE"):$PATH"
+	CXXFLAGS+=" --target=$CCTERMUX_HOST_PLATFORM"
+	CFLAGS+=" --target=$CCTERMUX_HOST_PLATFORM"
+	LDFLAGS+=" --target=$CCTERMUX_HOST_PLATFORM"
 }

--- a/x11-packages/ncspot-mpris/build.sh
+++ b/x11-packages/ncspot-mpris/build.sh
@@ -3,15 +3,13 @@ TERMUX_PKG_DESCRIPTION="An ncurses Spotify client written in Rust (with MPRIS su
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.2.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/hrkfdn/ncspot/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=6bd08609a56aa5854a1964c9a872fe58b69a768d7d94c874d40d7a8848241213
 TERMUX_PKG_DEPENDS="dbus, pulseaudio"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
-
 TERMUX_PKG_CONFLICTS="ncspot"
-
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --no-default-features
 --features termion_backend,pulseaudio_backend,mpris,notify
@@ -29,4 +27,25 @@ termux_step_pre_configure() {
 	cargo install --force --locked bindgen-cli@0.69.5
 
 	export TARGET_CMAKE_GENERATOR="Ninja"
+
+	# Setup subsequent cmake running inside cargo
+	# Crate used to invoke cmake does not work fine with cross-compilation so we wrap cmake
+	_CMAKE="$TERMUX_PKG_TMPDIR/bin/cmake"
+	mkdir -p "$(dirname "$_CMAKE")"
+
+	echo "#!$(readlink /proc/$$/exe)" > "$_CMAKE"
+	echo "echo CMAKE \"\$@\"" >> "$_CMAKE"
+	echo "[[ \"\$@\" =~ \"--build\" ]] && exec $(command -v cmake) \"\$@\" || \
+	exec $(command -v cmake) \
+	-DCMAKE_ANDROID_STANDALONE_TOOLCHAIN=\"$TERMUX_STANDALONE_TOOLCHAIN\" \
+	-DCMAKE_SYSTEM_NAME=Android \
+	-DCMAKE_SYSTEM_VERSION=$TERMUX_PKG_API_LEVEL \
+	-DCMAKE_LINKER=\"$TERMUX_STANDALONE_TOOLCHAIN/bin/$LD\" \
+	-DCMAKE_MAKE_PROGRAM=\"$(command -v ninja)\" \"\$@\"" >> "$_CMAKE"
+	chmod +x "$_CMAKE"
+
+	export PATH="$(dirname "$_CMAKE"):$PATH"
+	CXXFLAGS+=" --target=$CCTERMUX_HOST_PLATFORM"
+	CFLAGS+=" --target=$CCTERMUX_HOST_PLATFORM"
+	LDFLAGS+=" --target=$CCTERMUX_HOST_PLATFORM"
 }


### PR DESCRIPTION
It is not clear to me why previous commits
67cc1b95f28e13077187736af783469f41f8f46a
7b2f9c5a3d28273848844c63d856ecfc90488bb1
worked when removing the cmake wrapper but now doesnt.

Restoring the cmake wrapper for now instead of breaking build.